### PR TITLE
Use GitHub CLI to create release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish to PyPI
 on:
   # Triggers the workflow on push for the "main" branch
   push:
-    branches: ["main"]
+    branches: [ "main" ]
 
 jobs:
   pypi-publish:
@@ -31,27 +31,25 @@ jobs:
       - name: 🦑 Fetch package version
         run: |
           echo "CURRENT_VERSION=v$(poetry version --short)" >> $GITHUB_ENV
+          echo "PRE_RELEASE=$(poetry version --short | cut -d'.' -f3)" >> $GITHUB_ENV
           echo "Version = v$(poetry version --short)"
 
       - name: 🏗 Build package
-        if: |
-          github.ref == 'refs/heads/main' && 
-          github.event_name == 'push'
         run: poetry build
 
       - name: 📰 Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: 🏷️ Create tag
-        if: |
-          github.ref == 'refs/heads/main' && 
-          github.event_name == 'push'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ env.CURRENT_VERSION }}',
-              sha: context.sha
-            })
+      # Check if the version is a pre-release by looking for the presence of 'a', 'b', or 'rc' in the version number.
+      - name: 🏷️ Create release (or pre-release)
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        shell: bash
+        run: |
+          if [[ "${{ env.CURRENT_VERSION }}" == *(a|b|rc)* ]]; then
+            echo "Creating pre-release ${{ env.CURRENT_VERSION }}"
+            gh release create --prerelease ${{ env.CURRENT_VERSION }} dist/*
+          else
+            echo "Creating release ${{ env.CURRENT_VERSION }}"
+            gh release create ${{ env.CURRENT_VERSION }} dist/*
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toadr3"
-version = "0.1.5a2"
+version = "0.1.5a3"
 description = "Tiny OpenADR 3 compatible client Python Library"
 authors = ["Jean-Paul Balabanian <jean-paul.balabanian@eviny.no>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Checks if the version contains 'a', 'b' or 'rc' as indicators to mark the release as pre-release.