### PR TITLE
Rename ObjectTypes and OperationTypes to ObjectType and OperationType

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ operations towards a VTN.
 
 Currently, it supports the following operations:
 
-- List events
+- List events [GET]
   - Filter by program id
   - Filter by target type and target values
   - Limit and skip for pagination
-- List reports
+- List reports [GET]
   - Filter by program id
   - Filter by event id
   - Filter by client name
   - Limit and skip for pagination
-- Create a report from an event
+- Create a report [POST]
+- Create a report object based on an initial event
 
 ## Example
 A small example of how to list events and reports from a VTN:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toadr3"
-version = "0.13.0"
+version = "0.14.0"
 description = "Tiny OpenADR 3 compatible client Python Library"
 authors = ["Jean-Paul Balabanian <jean-paul.balabanian@eviny.no>"]
 license = "Apache-2.0"

--- a/tests/test_subscription.py
+++ b/tests/test_subscription.py
@@ -1,4 +1,4 @@
-from toadr3.models import ObjectOperation, ObjectTypes, OperationTypes, Subscription
+from toadr3.models import ObjectOperation, ObjectType, OperationType, Subscription
 
 
 def test_subscription() -> None:
@@ -8,13 +8,13 @@ def test_subscription() -> None:
         "programID": "programId",
         "objectOperations": [
             {
-                "objects": [ObjectTypes.EVENT],
-                "operations": [OperationTypes.POST],
+                "objects": [ObjectType.EVENT],
+                "operations": [OperationType.POST],
                 "callbackUrl": "url://callback",
             },
             ObjectOperation(
-                objects=[ObjectTypes.PROGRAM, ObjectTypes.REPORT],
-                operations=[OperationTypes.PUT, OperationTypes.DELETE],
+                objects=[ObjectType.PROGRAM, ObjectType.REPORT],
+                operations=[OperationType.PUT, OperationType.DELETE],
                 callback_url="url://callback2",
                 bearer_token="token",
             ),
@@ -33,14 +33,14 @@ def test_subscription() -> None:
     assert subscription.program_id == "programId"
     assert len(subscription.object_operations) == 2
     op_0 = subscription.object_operations[0]
-    assert op_0.objects == [ObjectTypes.EVENT]
-    assert op_0.operations == [OperationTypes.POST]
+    assert op_0.objects == [ObjectType.EVENT]
+    assert op_0.operations == [OperationType.POST]
     assert op_0.callback_url == "url://callback"
     assert op_0.bearer_token is None
 
     op_1 = subscription.object_operations[1]
-    assert op_1.objects == [ObjectTypes.PROGRAM, ObjectTypes.REPORT]
-    assert op_1.operations == [OperationTypes.PUT, OperationTypes.DELETE]
+    assert op_1.objects == [ObjectType.PROGRAM, ObjectType.REPORT]
+    assert op_1.operations == [OperationType.PUT, OperationType.DELETE]
     assert op_1.callback_url == "url://callback2"
     assert op_1.bearer_token == "token"
 

--- a/toadr3/models/__init__.py
+++ b/toadr3/models/__init__.py
@@ -3,7 +3,7 @@ from .event import Event
 from .eventpayloaddescriptor import EventPayloadDescriptor
 from .interval import Interval
 from .intervalperiod import IntervalPeriod
-from .objectoperation import ObjectOperation, ObjectTypes, OperationTypes
+from .objectoperation import ObjectOperation, ObjectType, OperationType
 from .report import Report
 from .reportdata import ReportData
 from .reportdescriptor import ReportDescriptor
@@ -19,8 +19,8 @@ __all__ = [
     "Interval",
     "IntervalPeriod",
     "ObjectOperation",
-    "ObjectTypes",
-    "OperationTypes",
+    "ObjectType",
+    "OperationType",
     "Point",
     "Report",
     "ReportData",

--- a/toadr3/models/objectoperation.py
+++ b/toadr3/models/objectoperation.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from toadr3.models import DocstringBaseModel
 
 
-class ObjectTypes(StrEnum):
+class ObjectType(StrEnum):
     """Types of objects addressable through API."""
 
     EVENT = "EVENT"
@@ -14,7 +14,7 @@ class ObjectTypes(StrEnum):
     VEN = "VEN"
 
 
-class OperationTypes(StrEnum):
+class OperationType(StrEnum):
     """Object operation to subscribe to."""
 
     DELETE = "DELETE"
@@ -26,10 +26,10 @@ class OperationTypes(StrEnum):
 class ObjectOperation(DocstringBaseModel):
     """Object type, operations, and callbackUrl."""
 
-    objects: list[ObjectTypes]
+    objects: list[ObjectType]
     """List of objects to subscribe to."""
 
-    operations: list[OperationTypes]
+    operations: list[OperationType]
     """List of operations to subscribe to."""
 
     callback_url: str


### PR DESCRIPTION
This change updates class names to use singular forms for consistency and clarity. Adjustments are made across models, tests, and imports to reflect the renaming.