### PR TITLE
Improved Mock server exception handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toadr3"
-version = "0.14.3"
+version = "0.14.4"
 description = "Tiny OpenADR 3 compatible client Python Library"
 authors = ["Jean-Paul Balabanian <jean-paul.balabanian@eviny.no>"]
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import traceback
+from typing import Awaitable, Callable
+
 import pytest
 from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
@@ -6,12 +9,43 @@ from mock_vtn_server import MockVTNServer
 from toadr3 import OAuthConfig, ToadrClient
 
 
+async def _exception_wrapper(
+    func: Callable[[web.Request], Awaitable[web.Response]],
+) -> Callable[[web.Request], Awaitable[web.Response]]:
+    """Wrap a function and catch all exceptions.
+
+    Since the web.Application will fail if an exception is raised, this catches these
+    exceptions and creates an internal server error (500) instead.
+    """
+
+    async def wrapper(request: web.Request) -> web.Response:
+        try:
+            return await func(request)
+        except BaseException as e:  # noqa: BLE001
+            return web.json_response(
+                data={
+                    "error": f"An unexpected error occurred: {e}",
+                    "error_description": "The MockVTNServer raised an exception instead of "
+                    "producing a 'web.Response' object.\n"
+                    f"{'*' * 50}\n"
+                    "Exception info:\n"
+                    f"{''.join(traceback.format_exception(e))}"
+                    f"{'*' * 50}\n",
+                },
+                status=500,
+            )
+
+    return wrapper
+
+
 @pytest.fixture
 async def client(aiohttp_client: AiohttpClient) -> ToadrClient:
     vtn_server = MockVTNServer()
 
     app = web.Application()
-    app.router.add_post("/oauth_url/token_endpoint", vtn_server.token_post_response)
+    app.router.add_post(
+        "/oauth_url/token_endpoint", await _exception_wrapper(vtn_server.token_post_response)
+    )
 
     session = await aiohttp_client(app)
 


### PR DESCRIPTION
If the mock server failed and raised an error, the `web.Application` would silently ignore and later produce a disconnected error. This will ensure that any exceptions in the server will result in proper `web.Responses`.