### PR TITLE
Rework how claims are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import toadr3
 
 TOKEN_URL = ""  # URL to the OAuth2 token endpoint
 GRANT_TYPE = ""  # OAuth2 grant type
-SCOPE = ""  # OAuth2 scope
+CLAIMS = {"scope": ""}  # OAuth2 claims, e.g. {"scope": "read write"}
 CLIENT_ID = ""  # OAuth2 client ID or set to None use environment variable
 CLIENT_SECRET = ""  # OAuth2 client secret or set to None use environment variable
 
@@ -47,7 +47,7 @@ VTN_URL = ""  # URL to the VTN
 async def main():
   async with aiohttp.ClientSession() as session:
     token = await toadr3.acquire_access_token(
-      session, TOKEN_URL, GRANT_TYPE, SCOPE, CLIENT_ID, CLIENT_SECRET
+      session, TOKEN_URL, GRANT_TYPE, CLAIMS, CLIENT_ID, CLIENT_SECRET
     )
 
     events = await toadr3.get_events(session, VTN_URL, token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toadr3"
-version = "0.14.6"
+version = "0.15.0"
 description = "Tiny OpenADR 3 compatible client Python Library"
 authors = ["Jean-Paul Balabanian <jean-paul.balabanian@eviny.no>"]
 license = "Apache-2.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
 from mock_vtn_server import MockVTNServer
 
-from toadr3 import OAuthConfig, ToadrClient
+from toadr3 import OAuthScopeConfig, ToadrClient
 
 
 async def _exception_wrapper(
@@ -49,7 +49,7 @@ async def client(aiohttp_client: AiohttpClient) -> ToadrClient:
 
     session = await aiohttp_client(app)
 
-    oauth_config = OAuthConfig(
+    oauth_config = OAuthScopeConfig(
         token_url="/oauth_url/token_endpoint",
         grant_type="client_credentials",
         scope="test_scope",

--- a/tests/test_client_oauth.py
+++ b/tests/test_client_oauth.py
@@ -48,7 +48,7 @@ async def test_token_unsupported_grant_type(client: toadr3.ToadrClient) -> None:
 
 async def test_token_scope_error(client: toadr3.ToadrClient) -> None:
     assert client._oauth_config is not None  # noqa: SLF001
-    client._oauth_config._scope = "wrong_scope"  # noqa: SLF001
+    client._oauth_config._claims["scope"] = "wrong_scope"  # noqa: SLF001
 
     with pytest.raises(toadr3.ToadrError, match="invalid_scope") as exc:
         await client.token

--- a/toadr3/__init__.py
+++ b/toadr3/__init__.py
@@ -1,7 +1,9 @@
 from . import models
 from .access_token import (
     AccessToken,
+    OAuthAudienceConfig,
     OAuthConfig,
+    OAuthScopeConfig,
     acquire_access_token,
     acquire_access_token_from_config,
 )
@@ -13,6 +15,8 @@ from .reports import get_reports, post_report
 __all__ = [
     "AccessToken",
     "OAuthConfig",
+    "OAuthScopeConfig",
+    "OAuthAudienceConfig",
     "ToadrClient",
     "ToadrError",
     "acquire_access_token",


### PR DESCRIPTION
To add support for `audience` in addition to `scope` type of claim, it is now possible to send a dict containing all required claim types during configuration of the `oauth` provider.