### PR TITLE
Add exception documentation for unhandled aiohttp errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "toadr3"
-version = "0.15.0"
+version = "0.15.1"
 description = "Tiny OpenADR 3 compatible client Python Library"
 authors = ["Jean-Paul Balabanian <jean-paul.balabanian@eviny.no>"]
 license = "Apache-2.0"

--- a/toadr3/events.py
+++ b/toadr3/events.py
@@ -52,7 +52,9 @@ async def get_events(
     ValueError
         If the query parameters are invalid.
     toadr3.ToadrError
-        If the request to the VTN fails.
+        If the request to the VTN fails. Specifically, if the response status is 400, 403, or 500,
+    aiohttp.ClientError
+        If there is an unexpected error with the HTTP request to the VTN.
     """
     _check_arguments(target_type, target_values, skip, limit)
 

--- a/toadr3/reports.py
+++ b/toadr3/reports.py
@@ -32,7 +32,10 @@ async def post_report(
     Raises
     ------
     toadr3.ToadrError
-        If the request to the VTN fails.
+        If the request to the VTN fails. Specifically, if the
+        response status is 400, 403, 409, or 500,
+    aiohttp.ClientError
+        If there is an unexpected error with the HTTP request to the VTN.
     """
     if report is None:
         raise ValueError("report is required")
@@ -116,7 +119,9 @@ async def get_reports(
     ValueError
         If the query parameters are invalid.
     toadr3.ToadrException
-        If the request to the VTN fails.
+        If the request to the VTN fails. Specifically, if the response status is 400, 403, or 500,
+    aiohttp.ClientError
+        If there is an unexpected error with the HTTP request to the VTN.
     """
     _check_arguments(skip, limit)
     params = _create_query_parameters(program_id, event_id, client_name, skip, limit)


### PR DESCRIPTION
Document that `aiohttp` raises some errors that `toadr3` ignores. 